### PR TITLE
Scoop update for wriftai version v0.48.0

### DIFF
--- a/bucket/wriftai.json
+++ b/bucket/wriftai.json
@@ -1,19 +1,19 @@
 {
-    "version": "0.47.0",
+    "version": "0.48.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/wriftai/cli/releases/download/v0.47.0/wriftai_Windows_x86_64.zip",
+            "url": "https://github.com/wriftai/cli/releases/download/v0.48.0/wriftai_Windows_x86_64.zip",
             "bin": [
                 "wriftai.exe"
             ],
-            "hash": "74a122ac7d0e5ee6b7347044a1e158b7bba3ebefc4521caecb43d7e68d16c2bc"
+            "hash": "c271c293c4e2194726253833ce22771d5d0d63b4e7ee2b3f03b687490d6b6701"
         },
         "arm64": {
-            "url": "https://github.com/wriftai/cli/releases/download/v0.47.0/wriftai_Windows_arm64.zip",
+            "url": "https://github.com/wriftai/cli/releases/download/v0.48.0/wriftai_Windows_arm64.zip",
             "bin": [
                 "wriftai.exe"
             ],
-            "hash": "a46f2d5d88aa32afbf16ac31fa28e496f3bf42cf3e57f22055bbe917db45d8e4"
+            "hash": "2b5ad86c2e00f4425968a0a5017b2d064ce96d12b1b94d7a029367925efa3042"
         }
     },
     "homepage": "https://github.com/wriftai/cli",


### PR DESCRIPTION

###### Automated with [GoReleaser](https://goreleaser.com)